### PR TITLE
Add accessible modal for site search

### DIFF
--- a/wp-content/themes/Radio huaya/components/c-header.php
+++ b/wp-content/themes/Radio huaya/components/c-header.php
@@ -41,12 +41,12 @@
 
    
       <!-- Botón para abrir el modal de busqueda -->
-      <button 
+      <button
         class="header__search-btn modal-buscador"
-        id="openModal" 
+        id="openModal"
         type="button"
         aria-expanded="false"
-        aria-controls="modalSearch"
+        aria-controls="myModal"
         aria-label="Abrir modal de búsqueda">
         <i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
       </button>
@@ -91,12 +91,12 @@
         <ul>
           <li>
             <!-- Botón para abrir el modal de busqueda -->
-            <button 
+            <button
               class="header__search-btn  header__search-btn--lg modal-buscador"
-              id="openModal2" 
+              id="openModal2"
               type="button"
               aria-expanded="false"
-              aria-controls="modalSearch"
+              aria-controls="myModal"
               aria-label="Abrir modal de búsqueda">
               <i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
             </button>

--- a/wp-content/themes/Radio huaya/components/moduls/m-modal.php
+++ b/wp-content/themes/Radio huaya/components/moduls/m-modal.php
@@ -5,6 +5,7 @@
   role="dialog"
   aria-modal="true"
   aria-labelledby="modalTitle"
+  aria-hidden="true"
   hidden
 >
   <!-- Fondo oscuro clicable para cerrar el modal -->
@@ -28,15 +29,29 @@
 
     <!-- Cuerpo de texto del modal -->
     <p class="modal__text">
-    Explora los contenidos de nuestra radio comunitaria: noticias, programas, podcasts y series que recogen las voces, memorias y saberes de los pueblos originarios.
+      Explora los contenidos de nuestra radio comunitaria: noticias, programas, podcasts y series que recogen las voces, memorias y saberes de los pueblos originarios.
     </p>
-    <input type="text" placeholder="Escribe una palabra clave">
 
-
-    <!-- Botón de acción dentro del modal -->
-    <button class="btn btn--black" type="button">
-      Buscar
-    </button>
+    <form
+      class="modal__form"
+      role="search"
+      method="get"
+      action="<?php echo esc_url( home_url( '/' ) ); ?>"
+    >
+      <label class="u-sr-only" for="modalSearchInput">Buscar contenidos en Radio Huaya</label>
+      <input
+        class="modal__input"
+        type="search"
+        id="modalSearchInput"
+        name="s"
+        placeholder="Escribe una palabra clave"
+        value="<?php echo esc_attr( get_search_query() ); ?>"
+        required
+      />
+      <button class="modal__submit btn btn--black" type="submit">
+        Buscar
+      </button>
+    </form>
   </div>
 </section>
 

--- a/wp-content/themes/Radio huaya/sass/elements/_buttons.scss
+++ b/wp-content/themes/Radio huaya/sass/elements/_buttons.scss
@@ -145,6 +145,17 @@ $border-btn: 0.2rem;
     }
   }
 
+  &--black {
+    background-color: vars.$color-text;
+    border: $border-btn solid vars.$color-text;
+    color: vars.$color-white;
+
+    &:hover {
+      background-color: transparent;
+      color: vars.$color-text;
+    }
+  }
+
   &--icon {
     i {
       color: vars.$color-primary;

--- a/wp-content/themes/Radio huaya/sass/moduls/_modal.scss
+++ b/wp-content/themes/Radio huaya/sass/moduls/_modal.scss
@@ -81,4 +81,40 @@
     right: 0;
     top: 0;
   }
+
+  &__form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+
+    @include mix.respond-to(sm) {
+      gap: 1.25rem;
+    }
+  }
+
+  &__input {
+    border: 3px solid vars.$color-text;
+    border-radius: vars.$radius-md;
+    font-size: fn.rem(16);
+    padding: 0.75rem 1rem;
+    width: 100%;
+
+    &::placeholder {
+      color: rgba(vars.$color-text, 0.6);
+    }
+
+    &:focus {
+      border-color: vars.$color-primary;
+      box-shadow: 0 0 0 0.125rem rgba(vars.$color-primary, 0.4);
+      outline: none;
+    }
+  }
+
+  &__submit {
+    align-self: flex-start;
+  }
+}
+
+body.modal-open {
+  overflow: hidden;
 }

--- a/wp-content/themes/Radio huaya/script.js
+++ b/wp-content/themes/Radio huaya/script.js
@@ -267,8 +267,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
 $(function () {
   const $modal = $('#myModal');
+  const $modalTriggers = $('.modal-buscador');
   const focusableElementsSelector = 'a, button, textarea, input, select, [tabindex]:not([tabindex="-1"])';
   let previousFocus = null;
+
+  if (!$modal.length) return;
 
   function trapFocus(e) {
     if (e.key !== 'Tab') return;
@@ -279,30 +282,48 @@ $(function () {
 
     if (e.shiftKey && document.activeElement === first) {
       e.preventDefault();
-      last.focus();
+      last?.focus();
     } else if (!e.shiftKey && document.activeElement === last) {
       e.preventDefault();
-      first.focus();
+      first?.focus();
     }
   }
 
-  function openModal() {
+  function openModal(event) {
+    if (!$modal.is('[hidden]')) return;
+
+    event?.preventDefault();
     previousFocus = document.activeElement;
+
+    $modalTriggers.attr('aria-expanded', 'true');
+    $('body').addClass('modal-open');
+
     $modal.removeAttr('hidden').attr('aria-hidden', 'false');
     $modal.find(focusableElementsSelector).first().focus();
+
     $(document).on('keydown', trapFocus);
   }
 
   function closeModal() {
+    if ($modal.is('[hidden]')) return;
+
     $modal.attr('hidden', true).attr('aria-hidden', 'true');
+    $modalTriggers.attr('aria-expanded', 'false');
+    $('body').removeClass('modal-open');
+
     previousFocus?.focus();
+    previousFocus = null;
+
     $(document).off('keydown', trapFocus);
   }
 
-  $('.modal-buscador').on('click', openModal);
+  $modalTriggers.on('click', openModal);
   $('#closeModal, #modalOverlay').on('click', closeModal);
   $(document).on('keydown', (e) => {
-    if (e.key === 'Escape') closeModal();
+    if (e.key === 'Escape' && !$modal.is('[hidden]')) {
+      e.preventDefault();
+      closeModal();
+    }
   });
 });
 

--- a/wp-content/themes/Radio huaya/styles.css
+++ b/wp-content/themes/Radio huaya/styles.css
@@ -443,6 +443,15 @@ p {
   background-color: #000;
   color: #fefacd;
 }
+.btn--black {
+  background-color: #000;
+  border: 0.2rem solid #000;
+  color: #fefacd;
+}
+.btn--black:hover {
+  background-color: transparent;
+  color: #000;
+}
 .btn--icon i {
   color: #019640;
   font-size: 1rem;
@@ -1146,6 +1155,38 @@ input[type=text] {
   position: absolute;
   right: 0;
   top: 0;
+}
+.modal__form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+@media (width >= 420px) {
+  .modal__form {
+    gap: 1.25rem;
+  }
+}
+.modal__input {
+  border: 3px solid #000;
+  border-radius: 0.5rem;
+  font-size: 1rem;
+  padding: 0.75rem 1rem;
+  width: 100%;
+}
+.modal__input::placeholder {
+  color: rgba(0, 0, 0, 0.6);
+}
+.modal__input:focus {
+  border-color: #019640;
+  box-shadow: 0 0 0 0.125rem rgba(1, 150, 64, 0.4);
+  outline: none;
+}
+.modal__submit {
+  align-self: flex-start;
+}
+
+body.modal-open {
+  overflow: hidden;
 }
 
 .pleca {


### PR DESCRIPTION
## Summary
- connect both header search triggers to a shared modal and expose accurate aria metadata
- replace the placeholder modal content with a functional WordPress search form and focus management updates
- style the modal form and new black button variant, including locking body scroll when open

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2ee72c0fc832ba02bf4dab07feb34