### PR TITLE
Add contact page template with map and form

### DIFF
--- a/wp-content/themes/Radio huaya/page-contacto.php
+++ b/wp-content/themes/Radio huaya/page-contacto.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Template Name: Plantilla de contacto
+ */
+
+get_header();
+?>
+
+<main id="main" class="contact-template">
+    <?php if ( have_posts() ) : ?>
+        <?php while ( have_posts() ) : the_post(); ?>
+            <div class="contact-template__wrapper">
+                <section class="contact-template__map" aria-label="Ubicación en el mapa">
+                    <iframe
+                        src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3764.620759851717!2d-99.13317822377937!3d19.34374448693317!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x85d1fff3e95f9643%3A0x9b13b6a1dc16109c!2sCiudad%20de%20M%C3%A9xico%2C%20CDMX%2C%20M%C3%A9xico!5e0!3m2!1ses!2smx!4v1700000000000!5m2!1ses!2smx"
+                        width="600"
+                        height="450"
+                        style="border:0;"
+                        allowfullscreen=""
+                        loading="lazy"
+                        referrerpolicy="no-referrer-when-downgrade"
+                        title="Mapa de contacto">
+                    </iframe>
+                </section>
+                <section class="contact-template__form">
+                    <header class="contact-template__header">
+                        <h1 class="contact-template__title"><?php the_title(); ?></h1>
+                        <div class="contact-template__content">
+                            <?php the_content(); ?>
+                        </div>
+                    </header>
+                    <form class="contact-template__form-fields" action="#" method="post">
+                        <div class="contact-template__field">
+                            <label class="contact-template__label" for="contact-name">Nombre</label>
+                            <input class="contact-template__input" type="text" id="contact-name" name="contact-name" required>
+                        </div>
+                        <div class="contact-template__field">
+                            <label class="contact-template__label" for="contact-email">Correo electrónico</label>
+                            <input class="contact-template__input" type="email" id="contact-email" name="contact-email" required>
+                        </div>
+                        <div class="contact-template__field">
+                            <label class="contact-template__label" for="contact-phone">Teléfono</label>
+                            <input class="contact-template__input" type="tel" id="contact-phone" name="contact-phone">
+                        </div>
+                        <div class="contact-template__field">
+                            <label class="contact-template__label" for="contact-message">Mensaje</label>
+                            <textarea class="contact-template__textarea" id="contact-message" name="contact-message" rows="5" required></textarea>
+                        </div>
+                        <div class="contact-template__actions">
+                            <button class="contact-template__submit" type="submit">Enviar mensaje</button>
+                        </div>
+                    </form>
+                </section>
+            </div>
+        <?php endwhile; ?>
+    <?php endif; ?>
+</main>
+
+<?php
+get_footer();

--- a/wp-content/themes/Radio huaya/style.css
+++ b/wp-content/themes/Radio huaya/style.css
@@ -759,3 +759,127 @@ body {
 }
 
 /*# sourceMappingURL=style.css.map */
+
+/* Plantilla de contacto */
+.contact-template {
+  padding: 2rem 1.5rem 3rem;
+}
+
+.contact-template__wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+@media (width >= 768px) {
+  .contact-template__wrapper {
+    flex-direction: row;
+    align-items: stretch;
+  }
+}
+
+.contact-template__map,
+.contact-template__form {
+  flex: 1 1 0;
+}
+
+.contact-template__map iframe {
+  width: 100%;
+  height: 100%;
+  min-height: 320px;
+  border-radius: 12px;
+  border: 0;
+}
+
+.contact-template__form {
+  background: #f5f5f5;
+  border-radius: 12px;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.contact-template__title {
+  font-family: "Oswald", sans-serif;
+  font-size: 2rem;
+  margin: 0;
+}
+
+@media (width >= 768px) {
+  .contact-template__title {
+    font-size: 2.5rem;
+  }
+}
+
+.contact-template__content {
+  font-size: 1rem;
+  color: #333;
+}
+
+.contact-template__form-fields {
+  display: grid;
+  gap: 1rem;
+}
+
+.contact-template__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.contact-template__label {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.contact-template__input,
+.contact-template__textarea {
+  width: 100%;
+  border: 1px solid #c7c7c7;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  font-family: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.contact-template__input:focus,
+.contact-template__textarea:focus {
+  outline: none;
+  border-color: #006699;
+  box-shadow: 0 0 0 3px rgba(0, 102, 153, 0.15);
+}
+
+.contact-template__textarea {
+  resize: vertical;
+  min-height: 160px;
+}
+
+.contact-template__actions {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.contact-template__submit {
+  background-color: #006699;
+  border: none;
+  border-radius: 999px;
+  color: #fff;
+  cursor: pointer;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  padding: 0.85rem 2.5rem;
+  text-transform: uppercase;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.contact-template__submit:hover,
+.contact-template__submit:focus {
+  background-color: #004f73;
+  transform: translateY(-1px);
+}
+
+.contact-template__submit:active {
+  transform: translateY(0);
+}


### PR DESCRIPTION
## Summary
- add a "Plantilla de contacto" page template featuring an embedded map and basic contact form fields
- style the contact template layout, map, and form controls to match the theme aesthetics

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2fa33f920832b8ca52ced4e035539